### PR TITLE
Hooks adding and dynamically migrating 'httpd-root'

### DIFF
--- a/maple-preview.el
+++ b/maple-preview.el
@@ -100,6 +100,7 @@ this hook providing more customization functional for as."
               (/
                (float (-  (line-number-at-pos) (/ (count-screen-lines (window-start) (point)) 2)))
                (count-lines (point-min) (point-max))))))))
+    (setq httpd-root default-directory)
     (websocket-send-text websocket
                          (concat
                           "<div id=\"position-percentage\" style=\"display:none;\">"


### PR DESCRIPTION
Maple-preview was awesome but with some details tracking for:

  * The core websocket interaction func `maple-preview:send-to-server` are used for whatever file content are, the limitation for sticking on `org` and `md` was enoughly
    > In fact the markdown export backend of ORG used for org previewng mechanism was not prefectly because of it's lagging with large buffer content converting remaining.  
  * The fixed httpd-root can not support file local image source rendering for.       
  * maple-preview was the global mode but without window configuration changing automatic trigger for the websocket interaction.
  

Thus for all the notice for the above description, I building some coding patchs for be against with:

- Two hooks adding for with internal default value binding with to consummating the websocket content auto-migration.
- Dynamically of `httpd-root` within  `maple-preview:send-to-server` :
  This one commonly efficient when the client browser not refreshing manually and first page render completely, because the initial procedure httpd using `maple-preview:home-path` as the root path before the first `send-to-sever`  procedure coming.
